### PR TITLE
Avoid using jinja tests as filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Task Variables
     required: true
     choices: [ "up", "down", "once" ]
     description:
-		Change the state of the service only if enabled='yes'
-		* up - Keep the service up, if it crashes or stops attempt to restart it.
-		* down - Bring the service down.
-		* once - Can only be run from the down state. Will start the service, however, will not restart if the service crashes.
+        Change the state of the service only if enabled='yes'
+        * up - Keep the service up, if it crashes or stops attempt to restart it.
+        * down - Bring the service down.
+        * once - Can only be run from the down state. Will start the service, however, will not restart if the service crashes.
   enabled:
     required: false
     default: ""
@@ -45,7 +45,7 @@ Task Variables
     description:
         - if enabled the service will be running and also will start on system boot
         if disabled the service will not be running and will not start on system boot
-		if not defined, there will be no change in the enabled state
+        if not defined, there will be no change in the enabled state
   timeout:
     default: 7
     required: false
@@ -56,8 +56,8 @@ Task Variables
     default: "yes"
     choices: [ "yes", "no" ]
     description:
-		- 'yes' Automatically creates the run_service_file and the log_service_file to execute the service.
-		requires the 'user' and 'command' values to be set
+        - 'yes' Automatically creates the run_service_file and the log_service_file to execute the service.
+        requires the 'user' and 'command' values to be set
         - 'no' The caller is required to create the run file and the run log file.
         See the notes for a more detailed explanation.
   command:
@@ -162,12 +162,12 @@ Example Playbook
 See test.yml for a working version.
 
     - hosts: servers
-	  sudo: true
+      sudo: true
 
       roles:
          - { role: gotansible.runit }
 
-	  tasks:
+      tasks:
       - name: place file to run
         copy: src=testrun.sh dest=/opt/runme mode=0755
 
@@ -176,12 +176,12 @@ See test.yml for a working version.
 
       - name: test runit
         runit: name=myservice enabled=true state=up timeout=9 user='root' command='bash /opt/runme'
-		register: myservice_status
-	  
+        register: myservice_status
+
 ### handler.yml
-	  - name: restart myservice
-		runit: name=myservice enabled=true state=up timeout=9 action=restart
-		when: not myservice_status.restarted
+      - name: restart myservice
+        runit: name=myservice enabled=true state=up timeout=9 action=restart
+        when: not myservice_status.restarted
 
 License
 -------

--- a/library/runit.py
+++ b/library/runit.py
@@ -16,7 +16,7 @@ notes:
     - This module creates a simple run file and run log file for your service.
     - Note: the role runit must be executed before this task
     -
-    - Due to the nature of runit, enabed='yes' will cause runit to start.
+    - Due to the nature of runit, enabled='yes' will cause runit to start.
     - In the auto='yes' mode you must provide a command for the run file to execute when you
     - want your service to start and provide the user the running service will run under.
     - However, if you want more control, you can set auto='no' and use the returned vars
@@ -258,8 +258,8 @@ def main():
             command_setup = dict(required=False, default=list(), type='list'),
             user = dict(required=False, default='root'),
             group = dict(required=False, default='')
-    #        signal = dict(required=False, choices=['HUP','CONT','TERM', 'KILL', 'USR1', 'USR2', 'STOP', 'ALRM', 'QUIT'], default=None),
-    #        validate = dict(required=False, default=None),
+    #       signal = dict(required=False, choices=['HUP','CONT','TERM', 'KILL', 'USR1', 'USR2', 'STOP', 'ALRM', 'QUIT'], default=None),
+    #       validate = dict(required=False, default=None),
         ),
         #add_file_common_args=True,
         supports_check_mode=True

--- a/library/runit.py
+++ b/library/runit.py
@@ -41,10 +41,10 @@ options:
     required: true
     choices: [ "up", "down", "once", "start", "stop" ]
     description:
-	    Change the state of the service only if enabled='yes'
-	    * up - Keep the service up, if it crashes or stops attempt to restart it.
-	    * down - Bring the service down.
-	    * once - Can only be run from the down state. Will start the service, however, will not restart if the service crashes.
+        Change the state of the service only if enabled='yes'
+        * up - Keep the service up, if it crashes or stops attempt to restart it.
+        * down - Bring the service down.
+        * once - Can only be run from the down state. Will start the service, however, will not restart if the service crashes.
         * start - wait timeout before determining if the service is running
         * stop - wait timeout before determining if the service has shutdown
   enabled:
@@ -65,8 +65,8 @@ options:
     default: "yes"
     choices: [ "yes", "no" ]
     description:
-	    - 'yes' Automatically creates the run_service_file and the log_service_file to execute the service.
-	    requires the 'user' and 'command' values to be set
+        - 'yes' Automatically creates the run_service_file and the log_service_file to execute the service.
+        requires the 'user' and 'command' values to be set
         - 'no' The caller is required to create the run file and the run log file.
         See the notes for a more detailed explanation.
   command:

--- a/library/runit_service.py
+++ b/library/runit_service.py
@@ -6,7 +6,7 @@ import tempfile
 
 DOCUMENTATION = '''
 ---
-module: runit
+module: runit_service
 version_added: "1.9.1"
 short_description: Sets up a runit service
 description:
@@ -107,10 +107,19 @@ options:
 
 EXAMPLES = '''
 
-# runit if enabled is in the running state
-- runit: name=myservicename enabled=yes state=running timeout=9
+# runit_service if enabled is in the running state
+- runit_service:
+    name: myservicename
+    enabled: yes
+    state: running
+    timeout=9
 
-- runit: name=myservicename enabled=yes state=running timeout=9 signal=HUP
+- runit:
+    name: myservicename
+    enabled: yes
+    state: running
+    timeout: 9
+    signal: HUP
 '''
 
 def get_status(module, name):
@@ -258,8 +267,8 @@ def main():
             command_setup = dict(required=False, default=list(), type='list'),
             user = dict(required=False, default='root'),
             group = dict(required=False, default='')
-    #       signal = dict(required=False, choices=['HUP','CONT','TERM', 'KILL', 'USR1', 'USR2', 'STOP', 'ALRM', 'QUIT'], default=None),
-    #       validate = dict(required=False, default=None),
+            # signal = dict(required=False, choices=['HUP','CONT','TERM', 'KILL', 'USR1', 'USR2', 'STOP', 'ALRM', 'QUIT'], default=None),
+            # validate = dict(required=False, default=None),
         ),
         #add_file_common_args=True,
         supports_check_mode=True

--- a/tasks/install_centos.yml
+++ b/tasks/install_centos.yml
@@ -7,7 +7,7 @@
 
 - name: centos - Add runit to yum
   shell: "curl -s https://packagecloud.io/install/repositories/imeyer/runit/script.rpm.sh | sudo bash"
-  when: runit_installed|failed
+  when: runit_installed is failed
 
 - name: centos - install package runit
   yum:

--- a/test.yml
+++ b/test.yml
@@ -43,7 +43,7 @@
       user: myservice
       group: myservice
       command: '/opt/runme'
-      commands_setup:
+      command_setup:
         - echo line1
         - echo line2
 

--- a/test.yml
+++ b/test.yml
@@ -35,7 +35,7 @@
   - pause: seconds=10
 
   - name: test runit
-    runit:
+    runit_service:
       name: myservice
       enabled: yes
       state: start


### PR DESCRIPTION
This avoids a [deprecation warning](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters) for Ansible 2.5 and later.